### PR TITLE
Feature/fix modal prompt bug and navigate to balances feature

### DIFF
--- a/src/components/MeBalances.tsx
+++ b/src/components/MeBalances.tsx
@@ -137,7 +137,7 @@ export const MeBalances: React.FC<Props> = ({ ...props }) => {
         let response = (await signatureRequestHandler.results().catch((error) => {
             debug(error);
             return undefined;
-        })) as { capTableClaimTokenVP: string }[] | undefined;
+        })) as { jwt: string }[] | undefined;
         if (!response) {
             toast(`Signering ble avbrutt.`);
             return;
@@ -146,7 +146,7 @@ export const MeBalances: React.FC<Props> = ({ ...props }) => {
             toast(`Feil i respons fra Lommebok.`)!;
             return;
         }
-        const claimVp = response[0].capTableClaimTokenVP;
+        const claimVp = response[0].jwt;
         const claimUnclaimedResponse = await claim(claimVp).catch((error) => {
             toast(error.message);
             return undefined;

--- a/src/context/BrokContext.tsx
+++ b/src/context/BrokContext.tsx
@@ -185,7 +185,8 @@ export const useBrok = () => {
                 <Box gap="small">
                     <Text size="xsmall">Se mer informasjon om aksjeeierene ved å koble til en lommebok.</Text>
                     <Button size="small" label="Koble til lommebok" onClick={() => initSigner()}></Button>
-                </Box>
+                </Box>,
+                { autoClose: 10000, onClose: () => setHasPromptedSigner(false) }
             );
             return undefined;
         }
@@ -197,7 +198,8 @@ export const useBrok = () => {
                 <Box gap="small">
                     <Text size="xsmall">Se mer informasjon om aksjeeierene ved å gi Forvalt tilgang til å hente data på dine vegne.</Text>
                     <Button size="small" label="Gi tilgang" onClick={() => fetchToken()}></Button>
-                </Box>
+                </Box>,
+                { autoClose: 10000, onClose: () => setHasPromptedToken(false) }
             );
         }
     }, [fetchToken, hasPromptedSigner, hasPromptedToken, initSigner, signer, state, token]);

--- a/src/pages/CapTablePage.tsx
+++ b/src/pages/CapTablePage.tsx
@@ -32,13 +32,14 @@ export const CapTablePage: React.FC<Props> = ({ ...props }) => {
     //     const _capTable = erc1400.connect(address)
     //     setCapTable(_capTable)
     // }, [erc1400, address])
-    const isCurrentWalletConntroller = !!currentSignerAddress && !!data && data.capTable.controllers.includes(currentSignerAddress.toLowerCase());
+    const isCurrentWalletConntroller =
+        !!currentSignerAddress && !!data && !!data.capTable && data.capTable.controllers.includes(currentSignerAddress.toLowerCase());
 
     return (
         <Box>
-            {loading && <Spinner></Spinner>}
+            {!data || !data.capTable || (loading && <Spinner></Spinner>)}
             {error && <Paragraph>Noe galt skjedde</Paragraph>}
-            {data && (
+            {data && data.capTable && (
                 <Box gap="small">
                     <Heading level={3}>Nøkkelopplysninger</Heading>
                     <CapTableDetails


### PR DESCRIPTION
Added onClose callback on toast that prompts for token and signer which reset state. This will allow for user beeing able to be prompted if not making action on first prompt.

Also in this pr added navigation from MeBalances -> Captable/:address if click on row